### PR TITLE
Add the mdbook-katex plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ ARG MDBOOK_TOC_VERSION="0.6.1"
 ARG MDBOOK_PLANTUML_VERSION="0.7.0"
 ARG MDBOOK_OPEN_ON_GH_VERSION="2.0.0"
 ARG MDBOOK_GRAPHVIZ_VERSION="0.0.2"
+ARG MDBOOK_KATEX_VERSION="0.2.8"
 
 ENV CARGO_INSTALL_ROOT /usr/local/
 ENV CARGO_TARGET_DIR /tmp/target/
@@ -22,6 +23,7 @@ RUN cargo install mdbook-toc --vers ${MDBOOK_TOC_VERSION} --verbose
 RUN cargo install mdbook-plantuml --vers ${MDBOOK_PLANTUML_VERSION} --verbose
 RUN cargo install mdbook-open-on-gh --vers ${MDBOOK_OPEN_ON_GH_VERSION} --verbose
 RUN cargo install mdbook-graphviz --vers ${MDBOOK_GRAPHVIZ_VERSION} --verbose
+RUN cargo install mdbook-katex --vers ${MDBOOK_KATEX_VERSION} --verbose
 
 # Create the final image
 FROM ubuntu:20.04

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Included binaries:
 - [mdbook-plantuml](https://crates.io/crates/mdbook-plantuml) - 0.7.0
 - [mdbook-open-on-gh](https://crates.io/crates/mdbook-open-on-gh) - 2.0.0
 - [mdbook-graphviz](https://crates.io/crates/mdbook-graphviz) - 0.0.2
+- [mdbook-katex](https://crates.io/crates/mdbook-katex) - 0.2.8
 
 Docker hub will automatically generate a new image and tag it with `latest`
 whenever new commits are pushed to this GitHub repo.


### PR DESCRIPTION
Hi @Michael-F-Bryan :wave:!

Thanks for this project, this is a helpful docker image to speed up compilation the mdbook in CI pipelines.
I'm using the katex plugin, do you think this would be open to adding this one as well?
I understand it's hard to find a good balance between including every plugin ever vs what most people actually use, but this is just a suggestion :smile: 