### PR TITLE
Add plantuml binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ EXPOSE 3000
 COPY --from=build /usr/local/bin/mdbook* /bin/
 
 # Make sure we have certs
-RUN apt-get update && apt-get install --no-install-recommends -y ca-certificates graphviz && rm -rf /var/cache/apt/lists
+RUN apt-get update && apt-get install --no-install-recommends -y ca-certificates graphviz plantuml && rm -rf /var/cache/apt/lists
 
 WORKDIR /data
 VOLUME [ "/data" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,8 @@ COPY --from=build /usr/local/bin/mdbook* /bin/
 # Make sure we have certs
 RUN apt-get update && apt-get install --no-install-recommends -y ca-certificates graphviz plantuml && rm -rf /var/cache/apt/lists
 
+COPY bin/plantuml /usr/bin/plantuml
+
 WORKDIR /data
 VOLUME [ "/data" ]
 

--- a/bin/plantuml
+++ b/bin/plantuml
@@ -1,0 +1,29 @@
+#!/bin/sh
+# PlantUML Launcher
+#
+# This script is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This script distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+# License for more details.
+# You should have received a copy of the GNU General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+# USA.
+#
+# Copyright (C) 2010 Ilya Paramonov <ivparamonov@gmail.com>
+
+if [ -n "${JAVA_HOME}" ] && [ -x "${JAVA_HOME}/bin/java" ] ; then
+    JAVA="${JAVA_HOME}/bin/java"
+elif [ -x /usr/bin/java ] ; then
+    JAVA=/usr/bin/java
+else
+    echo Cannot find JVM
+    exit 1
+fi
+
+$JAVA -jar -Djava.awt.headless=true -Djava.net.useSystemProxies=true /usr/share/plantuml/plantuml.jar ${@}


### PR DESCRIPTION
Without the plantuml binary installed within the docker container, the only way to run plantuml is with the remote server option. This seems to be not ideal because documentation builds will always need to be internet-connected.

This PR:
- adds the plantuml binary and it's dependencies using `apt-get` 
- modifies the plantuml launcher script to run it in headless mode. Without this, it will report an error upon invocation

Because `plantuml` has quite a few dependencies including a java runtime, this does unfortunately take the image size to 606MB (from 221MB)

```
root@9068962a4c53:/data# apt-get install plantuml
Reading package lists... Done
Building dependency tree       
Reading state information... Done
The following additional packages will be installed:
  alsa-topology-conf alsa-ucm-conf ant ant-optional at-spi2-core ca-certificates-java dbus default-jre default-jre-headless fonts-dejavu-extra icc-profiles-free java-common
  java-wrappers krb5-locales libapache-pom-java libapparmor1 libasound2 libasound2-data libatk-bridge2.0-0 libatk-wrapper-java libatk-wrapper-java-jni libatk1.0-0
  libatk1.0-data libatspi2.0-0 libavahi-client3 libavahi-common-data libavahi-common3 libavalon-framework-java libbatik-java libcommons-io-java libcommons-logging-java
  libcommons-parent-java libcups2 libdbus-1-3 libdrm-amdgpu1 libdrm-common libdrm-intel1 libdrm-nouveau2 libdrm-radeon1 libdrm2 libedit2 libel-api-java libelf1
  libfontbox2-java libfontenc1 libfop-java libgif7 libgl1 libgl1-mesa-dri libglapi-mesa libglvnd0 libglx-mesa0 libglx0 libgssapi-krb5-2 libjaxp1.3-java libjlatexmath-java
  libjsp-api-java libk5crypto3 libkeyutils1 libkrb5-3 libkrb5support0 liblcms2-2 libllvm12 libnspr4 libnss3 libpciaccess0 libpcsclite1 libqdox-java libsaxon-java
  libsensors-config libsensors5 libservlet-api-java libservlet3.1-java libsqlite3-0 libvulkan1 libwayland-client0 libwebsocket-api-java libx11-xcb1 libxalan2-java
  libxcb-dri2-0 libxcb-dri3-0 libxcb-glx0 libxcb-present0 libxcb-randr0 libxcb-shape0 libxcb-sync1 libxcb-xfixes0 libxcomposite1 libxerces2-java libxfixes3 libxft2 libxi6
  libxinerama1 libxkbfile1 libxml-commons-external-java libxml-commons-resolver1.1-java libxmlgraphics-commons-java libxmuu1 libxrandr2 libxshmfence1 libxtst6 libxv1
  libxxf86dga1 libxxf86vm1 mesa-vulkan-drivers openjdk-11-jre openjdk-11-jre-headless unzip x11-utils
Suggested packages:
  ant-doc default-jdk | java-compiler | java-sdk antlr javacc junit junit4 jython libactivation-java libbcel-java libbsf-java libcommons-net-java libmail-java
  libjdepend-java libjsch-java liblog4j1.2-java liboro-java libregexp-java libxz-java default-dbus-session-bus | dbus-session-bus libasound2-plugins alsa-utils
  libavalon-framework-java-doc librhino-java libcommons-io-java-doc libcommons-logging-java-doc libexcalibur-logkit-java cups-common krb5-doc krb5-user liblcms2-utils
  pciutils pcscd libqdox-java-doc libjdom1-java libsaxon-java-doc lm-sensors libxalan2-java-doc libxsltc-java libxerces2-java-doc libxml-commons-resolver1.1-java-doc
  libxmlgraphics-commons-java-doc libnss-mdns fonts-ipafont-gothic fonts-ipafont-mincho fonts-wqy-microhei | fonts-wqy-zenhei fonts-indic zip mesa-utils
The following NEW packages will be installed:
  alsa-topology-conf alsa-ucm-conf ant ant-optional at-spi2-core ca-certificates-java dbus default-jre default-jre-headless fonts-dejavu-extra icc-profiles-free java-common
  java-wrappers krb5-locales libapache-pom-java libapparmor1 libasound2 libasound2-data libatk-bridge2.0-0 libatk-wrapper-java libatk-wrapper-java-jni libatk1.0-0
  libatk1.0-data libatspi2.0-0 libavahi-client3 libavahi-common-data libavahi-common3 libavalon-framework-java libbatik-java libcommons-io-java libcommons-logging-java
  libcommons-parent-java libcups2 libdbus-1-3 libdrm-amdgpu1 libdrm-common libdrm-intel1 libdrm-nouveau2 libdrm-radeon1 libdrm2 libedit2 libel-api-java libelf1
  libfontbox2-java libfontenc1 libfop-java libgif7 libgl1 libgl1-mesa-dri libglapi-mesa libglvnd0 libglx-mesa0 libglx0 libgssapi-krb5-2 libjaxp1.3-java libjlatexmath-java
  libjsp-api-java libk5crypto3 libkeyutils1 libkrb5-3 libkrb5support0 liblcms2-2 libllvm12 libnspr4 libnss3 libpciaccess0 libpcsclite1 libqdox-java libsaxon-java
  libsensors-config libsensors5 libservlet-api-java libservlet3.1-java libsqlite3-0 libvulkan1 libwayland-client0 libwebsocket-api-java libx11-xcb1 libxalan2-java
  libxcb-dri2-0 libxcb-dri3-0 libxcb-glx0 libxcb-present0 libxcb-randr0 libxcb-shape0 libxcb-sync1 libxcb-xfixes0 libxcomposite1 libxerces2-java libxfixes3 libxft2 libxi6
  libxinerama1 libxkbfile1 libxml-commons-external-java libxml-commons-resolver1.1-java libxmlgraphics-commons-java libxmuu1 libxrandr2 libxshmfence1 libxtst6 libxv1
  libxxf86dga1 libxxf86vm1 mesa-vulkan-drivers openjdk-11-jre openjdk-11-jre-headless plantuml unzip x11-utils
0 upgraded, 110 newly installed, 0 to remove and 3 not upgraded.
Need to get 107 MB of archives.
After this operation, 700 MB of additional disk space will be used.
```